### PR TITLE
Fixed linking of properties inside Person and Project template files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 All notable changes to this project will be documented in this file.  
+
+## [1-0-1] - 2023-10-09
+### Fixed
+- Linking of `project-name` property in `Project Template` template with the title of the file created using the same template.
+- Linking of the `log` data with the `Project Template` templates's `Logs` dataview overview.
+- Linking of the `project-members` property with the `Person Template` template.
     
 ## [1-0-0] - 2023-03-29
 ### Added

--- a/__Templates/Person Template.md
+++ b/__Templates/Person Template.md
@@ -22,7 +22,7 @@ TABLE without id
  file.link as Project, project-client as Client, project-pm as PM
 FROM !"__Templates"
 WHERE tag = project 
-WHERE contains(project-members, this.file.name) 
+WHERE contains(project-members, this.file.link) 
 ```
 
 ## 🌅 Meetings 

--- a/__Templates/Project Template.md
+++ b/__Templates/Project Template.md
@@ -3,7 +3,7 @@ creation-date: <% tp.file.creation_date() %>
 modification-date: <% tp.file.last_modified_date("dddd Do MMMM YYYY HH:mm:ss") %>
 type: project
 tags: #project
-project-name: <% tp.file.title() %>   
+project-name: <% tp.file.title %>   
 ---
  
 ## Info 📑
@@ -28,7 +28,7 @@ WHERE contains(type, "meeting") and contains(project, this.file.link)
 TABLE
 rows.Details as "Details"
 from !"__Templates"
-WHERE contains(tag, this.file.name) 
+WHERE contains(log, this.file.name) 
 FLATTEN log as Details
 WHERE contains(Details, this.file.name) 
 GROUP BY file.link as Source


### PR DESCRIPTION
Fixed:
- Linking of `project-name` property in `Project Template` template with the title of the file created using the same template.
- Linking of the `log` data with the `Project Template` templates's `Logs` dataview overview.
- Linking of the `project-members` property with the `Person Template` template.